### PR TITLE
add w64 to sndfile scanner

### DIFF
--- a/scanner/inputaudio/sndfile/input_sndfile.c
+++ b/scanner/inputaudio/sndfile/input_sndfile.c
@@ -156,4 +156,4 @@ G_MODULE_EXPORT struct input_ops ip_ops = {
   sndfile_exit_library
 };
 
-G_MODULE_EXPORT const char* ip_exts[] = {"wav", "flac", "ogg", "oga", NULL};
+G_MODULE_EXPORT const char* ip_exts[] = {"wav", "flac", "ogg", "oga", "w64", NULL};


### PR DESCRIPTION
libsndfile supports w64 format which is useful for audio files over 4 GB